### PR TITLE
Properly loading horizon

### DIFF
--- a/horizon-behavior.html
+++ b/horizon-behavior.html
@@ -3,7 +3,7 @@
 <script>
     WIRSENS = window.WIRSENS || {};
 
-    var isReady = false;
+    var isLoading = false;
 
     /* @polymerBehavior */
     WIRSENS.HorizonBehavior = {
@@ -17,6 +17,12 @@
                 type: Object,
                 computed: '_computeHorizon(_horizonHost, _horizonPort, _isReady)',
                 notify: true
+            },
+
+            _handleLibLoaded: {
+                value: function () {
+                    return this._handleLibLoaded;
+                }
             }
         },
 
@@ -24,22 +30,34 @@
             '_loadLib(_horizonHost, _horizonPort)'
         ],
 
-        ready: function () {
-
+        attached: function () {
+            this._eventName = 'wirsens-horizon-script-loaded';
             var config = new Polymer.IronMetaQuery().byKey('horizon-config');
 
             this._horizonHost = !!config ? config.host : 'localhost';
             this._horizonPort = !!config ? config.port : '8181';
+
+            window.addEventListener(this._eventName, this._handleLibLoaded.bind(this));
+        },
+
+        _handleLibLoaded: function () {
+            this._isReady = true;
         },
 
         _loadLib: function (host, port) {
+
+            // check if someone else is loading
+            if (isLoading) {
+                return;
+            }
+
+            // we're first, let's load it
+            isLoading = true;
+
             var script = document.createElement('script');
             script.id = 'horizonScript';
 
             if (document.querySelector('#horizonScript')) {
-                if (isReady) {
-                    this._isReady = true;
-                }
                 return;
             }
 
@@ -49,13 +67,12 @@
                 src = location.hostname.replace('seats', 'horizon');
             }
 
-
             script.src = '//' + src + '/horizon/horizon.js';
             document.head.appendChild(script);
 
             script.onload = function () {
-                isReady = true;
-                this._isReady = true;
+                isLoading = false;
+                this.fire(this._eventName, {}, { node: window });
             }.bind(this);
         },
 
@@ -69,6 +86,10 @@
             return Horizon({
                 host: hostString
             });
+        },
+
+        detached: function () {
+            window.removeEventListener(this._eventName, this._handleLibLoaded);
         }
     };
 </script>

--- a/horizon-behavior.html
+++ b/horizon-behavior.html
@@ -17,12 +17,6 @@
                 type: Object,
                 computed: '_computeHorizon(_horizonHost, _horizonPort, _isReady)',
                 notify: true
-            },
-
-            _libLoadedHandler: {
-                value: function () {
-                    return this._handleLibLoaded;
-                }
             }
         },
 
@@ -37,7 +31,9 @@
             this._horizonHost = !!config ? config.host : 'localhost';
             this._horizonPort = !!config ? config.port : '8181';
 
-            window.addEventListener(this._eventName, this._libLoadedHandler.bind(this));
+            this._libLoadedHandler = this._handleLibLoaded.bind(this);
+
+            window.addEventListener(this._eventName, this._libLoadedHandler);
         },
 
         _handleLibLoaded: function () {
@@ -46,7 +42,7 @@
 
         _loadLib: function (host, port) {
 
-            // check if someone else is loading
+            // check if someone else is loading or if we already loaded the script
             if (isLoading) {
                 return;
             }
@@ -54,10 +50,16 @@
             // we're first, let's load it
             isLoading = true;
 
+            var scriptLoaded = function () {
+                isLoading = false;
+                this.fire(this._eventName, {}, { node: window });
+            }.bind(this);
+
             var script = document.createElement('script');
             script.id = 'horizonScript';
 
             if (document.querySelector('#horizonScript')) {
+                scriptLoaded();
                 return;
             }
 
@@ -70,10 +72,7 @@
             script.src = '//' + src + '/horizon/horizon.js';
             document.head.appendChild(script);
 
-            script.onload = function () {
-                isLoading = false;
-                this.fire(this._eventName, {}, { node: window });
-            }.bind(this);
+            script.onload = scriptLoaded;
         },
 
         _computeHorizon: function (host, port) {
@@ -89,7 +88,7 @@
         },
 
         detached: function () {
-            window.removeEventListener(this._eventName, this._handleLibLoaded);
+            window.removeEventListener(this._eventName, this._libLoadedHandler);
         }
     };
 </script>

--- a/horizon-behavior.html
+++ b/horizon-behavior.html
@@ -55,13 +55,13 @@
                 this.fire(this._eventName, {}, { node: window });
             }.bind(this);
 
-            var script = document.createElement('script');
-            script.id = 'horizonScript';
-
             if (document.querySelector('#horizonScript')) {
                 scriptLoaded();
                 return;
             }
+
+            var script = document.createElement('script');
+            script.id = 'horizonScript';
 
             var src = host + ':' + port;
 

--- a/horizon-behavior.html
+++ b/horizon-behavior.html
@@ -19,7 +19,7 @@
                 notify: true
             },
 
-            _handleLibLoaded: {
+            _libLoadedHandler: {
                 value: function () {
                     return this._handleLibLoaded;
                 }
@@ -37,7 +37,7 @@
             this._horizonHost = !!config ? config.host : 'localhost';
             this._horizonPort = !!config ? config.port : '8181';
 
-            window.addEventListener(this._eventName, this._handleLibLoaded.bind(this));
+            window.addEventListener(this._eventName, this._libLoadedHandler.bind(this));
         },
 
         _handleLibLoaded: function () {


### PR DESCRIPTION
There was a bug in how each behavior tried to load the Horizon library, resulting in it never setting its `_horizon` property and therefore never querying RethinkDB. Ej ej ej caramba